### PR TITLE
Fix: Use D1 binding name instead of database name in migrations

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,7 +77,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: d1 migrations apply ${{ github.ref == 'refs/heads/main' && 'zxcv-db' || 'zxcv-staging' }} --remote -c wrangler.toml ${{ github.ref == 'refs/heads/main' && '' || '--env staging' }}
+          command: d1 migrations apply DB --remote -c wrangler.toml ${{ github.ref == 'refs/heads/main' && '' || '--env staging' }}
           workingDirectory: 'server'
           
       - name: Deploy to Cloudflare Workers


### PR DESCRIPTION
The d1 migrations apply command requires the binding name (DB) not the database name. This fixes the error "Couldn't find a D1 DB with the name or binding 'zxcv-db'"