### PR TITLE
Fix: Correct database names in deployment migration command

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,7 +77,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: d1 migrations apply DB --remote -c wrangler.toml ${{ github.ref == 'refs/heads/main' && '' || '--env staging' }}
+          command: d1 migrations apply ${{ github.ref == 'refs/heads/main' && 'zxcv-db' || 'zxcv-staging' }} --remote -c wrangler.toml ${{ github.ref == 'refs/heads/main' && '' || '--env staging' }}
           workingDirectory: 'server'
           
       - name: Deploy to Cloudflare Workers


### PR DESCRIPTION
## Summary
- Fixed GitHub Actions deployment workflow to use correct database names instead of binding names
- Production uses `zxcv-db`, staging uses `zxcv-staging`  
- This resolves the migration failure in CI/CD pipeline

## Test plan
- [x] Verify deployment workflow syntax
- [ ] Test deployment on staging environment
- [ ] Confirm migrations run successfully

🤖 Generated with [Claude Code](https://claude.ai/code)