### PR TITLE
Fix: Resolve deployment migration command branch detection issues

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,7 +77,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: d1 migrations apply ${{ github.ref == 'refs/heads/main' && 'zxcv-db' || 'zxcv-staging' }} --remote -c wrangler.toml ${{ github.ref == 'refs/heads/main' && '' || '--env staging' }}
+          command: ${{ github.ref == 'refs/heads/main' && 'd1 migrations apply zxcv-db --remote -c wrangler.toml' || 'd1 migrations apply zxcv-staging --remote -c wrangler.toml --env staging' }}
           workingDirectory: 'server'
           
       - name: Deploy to Cloudflare Workers

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,13 +77,29 @@ jobs:
           echo "Current ref: ${{ github.ref }}"
           echo "Is main branch: ${{ github.ref == 'refs/heads/main' }}"
           echo "Environment: ${{ github.ref == 'refs/heads/main' && 'production' || 'staging' }}"
+          echo "Migration command will be:"
+          if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+            echo "d1 migrations apply zxcv-db --remote -c wrangler.toml"
+          else
+            echo "d1 migrations apply zxcv-staging --remote -c wrangler.toml --env staging"
+          fi
           
-      - name: Run migrations
+      - name: Run migrations (production)
+        if: github.ref == 'refs/heads/main'
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: ${{ github.ref == 'refs/heads/main' && 'd1 migrations apply zxcv-db --remote -c wrangler.toml' || 'd1 migrations apply zxcv-staging --remote -c wrangler.toml --env staging' }}
+          command: d1 migrations apply zxcv-db --remote -c wrangler.toml
+          workingDirectory: 'server'
+          
+      - name: Run migrations (staging)
+        if: github.ref == 'refs/heads/dev'
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: d1 migrations apply zxcv-staging --remote -c wrangler.toml --env staging
           workingDirectory: 'server'
           
       - name: Deploy to Cloudflare Workers

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,6 +72,12 @@ jobs:
           echo "=== Checking for .output/server/wrangler.json ==="
           ls -la .output/server/wrangler* 2>/dev/null || echo "No wrangler files in .output/server"
           
+      - name: Debug branch info
+        run: |
+          echo "Current ref: ${{ github.ref }}"
+          echo "Is main branch: ${{ github.ref == 'refs/heads/main' }}"
+          echo "Environment: ${{ github.ref == 'refs/heads/main' && 'production' || 'staging' }}"
+          
       - name: Run migrations
         uses: cloudflare/wrangler-action@v3
         with:


### PR DESCRIPTION
## Summary
- Fixed GitHub Actions deployment workflow migration command branch detection
- Split migration commands into explicit branch-based conditions
- Added debug information to track branch detection

## Changes
- Production (main): `d1 migrations apply zxcv-db --remote -c wrangler.toml`
- Staging (dev): `d1 migrations apply zxcv-staging --remote -c wrangler.toml --env staging`
- Added debug step to verify branch detection logic

## Test plan
- [x] Verify deployment workflow syntax
- [ ] Test staging deployment on dev branch
- [ ] Test production deployment on main branch
- [ ] Confirm migrations run successfully for both environments

🤖 Generated with [Claude Code](https://claude.ai/code)