### PR TITLE
Fix: Correct deployment environment configuration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -102,12 +102,34 @@ jobs:
           command: d1 migrations apply zxcv-staging --remote -c wrangler.toml --env staging
           workingDirectory: 'server'
           
-      - name: Deploy to Cloudflare Workers
+      - name: Deploy to Cloudflare Workers (production)
+        if: github.ref == 'refs/heads/main'
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: deploy -c wrangler.toml ${{ github.ref == 'refs/heads/main' && '' || '--env staging' }}
+          command: deploy -c wrangler.toml
+          workingDirectory: 'server'
+          secrets: |
+            JWT_SECRET
+            GOOGLE_CLIENT_ID
+            GOOGLE_CLIENT_SECRET
+            GH_OAUTH_CLIENT_ID
+            GH_OAUTH_CLIENT_SECRET
+        env:
+          JWT_SECRET: ${{ secrets.JWT_SECRET }}
+          GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
+          GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+          GH_OAUTH_CLIENT_ID: ${{ secrets.GH_OAUTH_CLIENT_ID }}
+          GH_OAUTH_CLIENT_SECRET: ${{ secrets.GH_OAUTH_CLIENT_SECRET }}
+          
+      - name: Deploy to Cloudflare Workers (staging)
+        if: github.ref == 'refs/heads/dev'
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: deploy -c wrangler.toml --env staging
           workingDirectory: 'server'
           secrets: |
             JWT_SECRET


### PR DESCRIPTION
## Summary
- Fixed deployment step to use correct environment configuration based on branch
- Split deployment commands into explicit branch-based conditions
- Ensures production uses production config and staging uses staging config

## Changes
- Production (main): `deploy -c wrangler.toml` (uses default production config)
- Staging (dev): `deploy -c wrangler.toml --env staging` (uses staging environment config)

## Problem Resolved
Previously, the deployment was showing "production" environment but using staging URLs and worker names due to incorrect condition evaluation in GitHub Actions.

## Test plan
- [ ] Verify production deployment uses correct URLs and worker name
- [ ] Verify staging deployment uses correct staging configuration
- [ ] Confirm environment variables are correctly set for each environment

🤖 Generated with [Claude Code](https://claude.ai/code)