### PR TITLE
Feat: Implement rule installation with memory file recording (#28)

### DIFF
--- a/cli/CLAUDE.md
+++ b/cli/CLAUDE.md
@@ -1,0 +1,3 @@
+# Claude Code Instructions
+
+AI coding rules for Claude Code

--- a/cli/bun.lock
+++ b/cli/bun.lock
@@ -4,9 +4,11 @@
     "": {
       "name": "zxcv",
       "dependencies": {
+        "@types/inquirer": "^9.0.9",
         "axios": "^1.11.0",
         "chalk": "^5.4.1",
         "commander": "^12.1.0",
+        "inquirer": "^12.9.4",
         "zod": "^3.25.76",
       },
       "devDependencies": {
@@ -36,11 +38,51 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@1.9.4", "", { "os": "win32", "cpu": "x64" }, "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA=="],
 
+    "@inquirer/checkbox": ["@inquirer/checkbox@4.2.2", "", { "dependencies": { "@inquirer/core": "^10.2.0", "@inquirer/figures": "^1.0.13", "@inquirer/type": "^3.0.8", "ansi-escapes": "^4.3.2", "yoctocolors-cjs": "^2.1.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-E+KExNurKcUJJdxmjglTl141EwxWyAHplvsYJQgSwXf8qiNWkTxTuCCqmhFEmbIXd4zLaGMfQFJ6WrZ7fSeV3g=="],
+
+    "@inquirer/confirm": ["@inquirer/confirm@5.1.16", "", { "dependencies": { "@inquirer/core": "^10.2.0", "@inquirer/type": "^3.0.8" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-j1a5VstaK5KQy8Mu8cHmuQvN1Zc62TbLhjJxwHvKPPKEoowSF6h/0UdOpA9DNdWZ+9Inq73+puRq1df6OJ8Sag=="],
+
+    "@inquirer/core": ["@inquirer/core@10.2.0", "", { "dependencies": { "@inquirer/figures": "^1.0.13", "@inquirer/type": "^3.0.8", "ansi-escapes": "^4.3.2", "cli-width": "^4.1.0", "mute-stream": "^2.0.0", "signal-exit": "^4.1.0", "wrap-ansi": "^6.2.0", "yoctocolors-cjs": "^2.1.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-NyDSjPqhSvpZEMZrLCYUquWNl+XC/moEcVFqS55IEYIYsY0a1cUCevSqk7ctOlnm/RaSBU5psFryNlxcmGrjaA=="],
+
+    "@inquirer/editor": ["@inquirer/editor@4.2.18", "", { "dependencies": { "@inquirer/core": "^10.2.0", "@inquirer/external-editor": "^1.0.1", "@inquirer/type": "^3.0.8" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-yeQN3AXjCm7+Hmq5L6Dm2wEDeBRdAZuyZ4I7tWSSanbxDzqM0KqzoDbKM7p4ebllAYdoQuPJS6N71/3L281i6w=="],
+
+    "@inquirer/expand": ["@inquirer/expand@4.0.18", "", { "dependencies": { "@inquirer/core": "^10.2.0", "@inquirer/type": "^3.0.8", "yoctocolors-cjs": "^2.1.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-xUjteYtavH7HwDMzq4Cn2X4Qsh5NozoDHCJTdoXg9HfZ4w3R6mxV1B9tL7DGJX2eq/zqtsFjhm0/RJIMGlh3ag=="],
+
+    "@inquirer/external-editor": ["@inquirer/external-editor@1.0.1", "", { "dependencies": { "chardet": "^2.1.0", "iconv-lite": "^0.6.3" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-Oau4yL24d2B5IL4ma4UpbQigkVhzPDXLoqy1ggK4gnHg/stmkffJE4oOXHXF3uz0UEpywG68KcyXsyYpA1Re/Q=="],
+
+    "@inquirer/figures": ["@inquirer/figures@1.0.13", "", {}, "sha512-lGPVU3yO9ZNqA7vTYz26jny41lE7yoQansmqdMLBEfqaGsmdg7V3W9mK9Pvb5IL4EVZ9GnSDGMO/cJXud5dMaw=="],
+
+    "@inquirer/input": ["@inquirer/input@4.2.2", "", { "dependencies": { "@inquirer/core": "^10.2.0", "@inquirer/type": "^3.0.8" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-hqOvBZj/MhQCpHUuD3MVq18SSoDNHy7wEnQ8mtvs71K8OPZVXJinOzcvQna33dNYLYE4LkA9BlhAhK6MJcsVbw=="],
+
+    "@inquirer/number": ["@inquirer/number@3.0.18", "", { "dependencies": { "@inquirer/core": "^10.2.0", "@inquirer/type": "^3.0.8" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-7exgBm52WXZRczsydCVftozFTrrwbG5ySE0GqUd2zLNSBXyIucs2Wnm7ZKLe/aUu6NUg9dg7Q80QIHCdZJiY4A=="],
+
+    "@inquirer/password": ["@inquirer/password@4.0.18", "", { "dependencies": { "@inquirer/core": "^10.2.0", "@inquirer/type": "^3.0.8", "ansi-escapes": "^4.3.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-zXvzAGxPQTNk/SbT3carAD4Iqi6A2JS2qtcqQjsL22uvD+JfQzUrDEtPjLL7PLn8zlSNyPdY02IiQjzoL9TStA=="],
+
+    "@inquirer/prompts": ["@inquirer/prompts@7.8.4", "", { "dependencies": { "@inquirer/checkbox": "^4.2.2", "@inquirer/confirm": "^5.1.16", "@inquirer/editor": "^4.2.18", "@inquirer/expand": "^4.0.18", "@inquirer/input": "^4.2.2", "@inquirer/number": "^3.0.18", "@inquirer/password": "^4.0.18", "@inquirer/rawlist": "^4.1.6", "@inquirer/search": "^3.1.1", "@inquirer/select": "^4.3.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-MuxVZ1en1g5oGamXV3DWP89GEkdD54alcfhHd7InUW5BifAdKQEK9SLFa/5hlWbvuhMPlobF0WAx7Okq988Jxg=="],
+
+    "@inquirer/rawlist": ["@inquirer/rawlist@4.1.6", "", { "dependencies": { "@inquirer/core": "^10.2.0", "@inquirer/type": "^3.0.8", "yoctocolors-cjs": "^2.1.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-KOZqa3QNr3f0pMnufzL7K+nweFFCCBs6LCXZzXDrVGTyssjLeudn5ySktZYv1XiSqobyHRYYK0c6QsOxJEhXKA=="],
+
+    "@inquirer/search": ["@inquirer/search@3.1.1", "", { "dependencies": { "@inquirer/core": "^10.2.0", "@inquirer/figures": "^1.0.13", "@inquirer/type": "^3.0.8", "yoctocolors-cjs": "^2.1.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-TkMUY+A2p2EYVY3GCTItYGvqT6LiLzHBnqsU1rJbrpXUijFfM6zvUx0R4civofVwFCmJZcKqOVwwWAjplKkhxA=="],
+
+    "@inquirer/select": ["@inquirer/select@4.3.2", "", { "dependencies": { "@inquirer/core": "^10.2.0", "@inquirer/figures": "^1.0.13", "@inquirer/type": "^3.0.8", "ansi-escapes": "^4.3.2", "yoctocolors-cjs": "^2.1.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-nwous24r31M+WyDEHV+qckXkepvihxhnyIaod2MG7eCE6G0Zm/HUF6jgN8GXgf4U7AU6SLseKdanY195cwvU6w=="],
+
+    "@inquirer/type": ["@inquirer/type@3.0.8", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-lg9Whz8onIHRthWaN1Q9EGLa/0LFJjyM8mEUbL1eTi6yMGvBf8gvyDLtxSXztQsxMvhxxNpJYrwa1YHdq+w4Jw=="],
+
     "@types/bun": ["@types/bun@1.2.19", "", { "dependencies": { "bun-types": "1.2.19" } }, "sha512-d9ZCmrH3CJ2uYKXQIUuZ/pUnTqIvLDS0SK7pFmbx8ma+ziH/FRMoAq5bYpRG7y+w1gl+HgyNZbtqgMq4W4e2Lg=="],
+
+    "@types/inquirer": ["@types/inquirer@9.0.9", "", { "dependencies": { "@types/through": "*", "rxjs": "^7.2.0" } }, "sha512-/mWx5136gts2Z2e5izdoRCo46lPp5TMs9R15GTSsgg/XnZyxDWVqoVU3R9lWnccKpqwsJLvRoxbCjoJtZB7DSw=="],
 
     "@types/node": ["@types/node@20.19.9", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-cuVNgarYWZqxRJDQHEB58GEONhOK79QVR/qYx4S7kcUObQvUwvFnYxJuuHUKm2aieN9X3yZB4LZsuYNU1Qphsw=="],
 
     "@types/react": ["@types/react@19.1.8", "", { "dependencies": { "csstype": "^3.0.2" } }, "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g=="],
+
+    "@types/through": ["@types/through@0.0.33", "", { "dependencies": { "@types/node": "*" } }, "sha512-HsJ+z3QuETzP3cswwtzt2vEIiHBk/dCcHGhbmG5X3ecnwFD/lPrMpliGXxSCg03L9AhrdwA4Oz/qfspkDW+xGQ=="],
+
+    "ansi-escapes": ["ansi-escapes@4.3.2", "", { "dependencies": { "type-fest": "^0.21.3" } }, "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ=="],
+
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
 
@@ -52,6 +94,14 @@
 
     "chalk": ["chalk@5.4.1", "", {}, "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w=="],
 
+    "chardet": ["chardet@2.1.0", "", {}, "sha512-bNFETTG/pM5ryzQ9Ad0lJOTa6HWD/YsScAR3EnCPZRPlQh77JocYktSHOUHelyhm8IARL+o4c4F1bP5KVOjiRA=="],
+
+    "cli-width": ["cli-width@4.1.0", "", {}, "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ=="],
+
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
     "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
 
     "commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
@@ -61,6 +111,8 @@
     "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
 
@@ -88,17 +140,45 @@
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
+    "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "inquirer": ["inquirer@12.9.4", "", { "dependencies": { "@inquirer/core": "^10.2.0", "@inquirer/prompts": "^7.8.4", "@inquirer/type": "^3.0.8", "ansi-escapes": "^4.3.2", "mute-stream": "^2.0.0", "run-async": "^4.0.5", "rxjs": "^7.8.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-5bV3LOgLtMAiJq1QpaUddfRrvaX59wiMYppS7z2jNRSQ64acI0yqx7WMxWhgymenSXOyD657g9tlsTjqGYM8sg=="],
+
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
     "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
     "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
+    "mute-stream": ["mute-stream@2.0.0", "", {}, "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA=="],
+
     "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
+
+    "run-async": ["run-async@4.0.6", "", {}, "sha512-IoDlSLTs3Yq593mb3ZoKWKXMNu3UpObxhgA/Xuid5p4bbfi2jdY1Hj0m1K+0/tEuQTxIGMhQDqGjKb7RuxGpAQ=="],
+
+    "rxjs": ["rxjs@7.8.2", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
+    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "type-fest": ["type-fest@0.21.3", "", {}, "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="],
 
     "typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
+
+    "yoctocolors-cjs": ["yoctocolors-cjs@2.1.3", "", {}, "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw=="],
 
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
   }

--- a/cli/package.json
+++ b/cli/package.json
@@ -20,9 +20,11 @@
 	"author": "",
 	"license": "MIT",
 	"dependencies": {
+		"@types/inquirer": "^9.0.9",
 		"axios": "^1.11.0",
 		"chalk": "^5.4.1",
 		"commander": "^12.1.0",
+		"inquirer": "^12.9.4",
 		"zod": "^3.25.76"
 	},
 	"devDependencies": {

--- a/cli/rules/@345e6t7yu/test.md
+++ b/cli/rules/@345e6t7yu/test.md
@@ -1,1 +1,0 @@
-../../../../../.zxcv/rules/@345e6t7yu/test.md

--- a/cli/src/commands/install.ts
+++ b/cli/src/commands/install.ts
@@ -4,6 +4,8 @@ import { Command } from "commander";
 import { ConfigManager } from "../config";
 import { ApiClient } from "../utils/api";
 import { FileManager } from "../utils/file";
+import { MemoryFileManager } from "../utils/memory-file";
+import { promptMemoryFile } from "../utils/prompt";
 import { ora } from "../utils/spinner.js";
 
 export function createInstallCommand(): Command {
@@ -13,207 +15,276 @@ export function createInstallCommand(): Command {
 		.argument("[path]", "Rule path to install (@owner/rulename)")
 		.option("--frozen-lockfile", "Don't update metadata, install exactly what's specified")
 		.option("-f, --force", "Force install even if rule already exists")
-		.action(async (path?: string, options?: { frozenLockfile?: boolean; force?: boolean }) => {
-			const config = new ConfigManager();
-			const api = new ApiClient(config);
-			const fileManager = new FileManager(config);
+		.option("--file <path>", "Specify memory file to record the rule")
+		.option("--no-warn", "Don't show warnings for non-project files")
+		.action(
+			async (
+				path?: string,
+				options?: { frozenLockfile?: boolean; force?: boolean; file?: string; noWarn?: boolean },
+			) => {
+				const config = new ConfigManager();
+				const api = new ApiClient(config);
+				const fileManager = new FileManager(config);
+				const memoryManager = new MemoryFileManager(config);
 
-			// If path is provided, install single rule
-			if (path) {
-				const spinner = ora("Installing rule...").start();
+				// If path is provided, install single rule
+				if (path) {
+					const spinner = ora("Installing rule...").start();
 
-				try {
-					// Parse path and version
-					let packageName = path;
-					let requestedVersion: string | undefined;
+					try {
+						// Parse path and version
+						let packageName = path;
+						let requestedVersion: string | undefined;
 
-					// Check for version specification (e.g., @user/rule@1.0.0)
-					const versionIndex = path.lastIndexOf("@");
-					if (versionIndex > 0) {
-						// Not the first @ in @org/rule
-						packageName = path.substring(0, versionIndex);
-						requestedVersion = path.substring(versionIndex + 1);
-					}
+						// Check for version specification (e.g., @user/rule@1.0.0)
+						const versionIndex = path.lastIndexOf("@");
+						if (versionIndex > 0) {
+							// Not the first @ in @org/rule
+							packageName = path.substring(0, versionIndex);
+							requestedVersion = path.substring(versionIndex + 1);
+						}
 
-					// Parse path - must be @owner/rulename format
-					if (!packageName.startsWith("@")) {
-						throw new Error("Rule path must be in @owner/rulename format");
-					}
+						// Parse path - must be @owner/rulename format
+						if (!packageName.startsWith("@")) {
+							throw new Error("Rule path must be in @owner/rulename format");
+						}
 
-					const pathParts = packageName.split("/");
-					if (pathParts.length !== 2) {
-						throw new Error("Rule path must be in @owner/rulename format");
-					}
+						const pathParts = packageName.split("/");
+						if (pathParts.length !== 2) {
+							throw new Error("Rule path must be in @owner/rulename format");
+						}
 
-					const owner = pathParts[0].substring(1); // Remove @ prefix
-					const ruleName = pathParts[1];
+						const owner = pathParts[0].substring(1); // Remove @ prefix
+						const ruleName = pathParts[1];
 
-					if (!owner || !ruleName) {
-						throw new Error("Invalid rule path format. Use @owner/rulename");
-					}
+						if (!owner || !ruleName) {
+							throw new Error("Invalid rule path format. Use @owner/rulename");
+						}
 
-					// Get rule from server (use packageName without version)
-					spinner.text("Fetching rule information...");
-					const rule = await api.getRule(packageName);
+						// Get rule from server (use packageName without version)
+						spinner.text("Fetching rule information...");
+						const rule = await api.getRule(packageName);
 
-					// Check if rule already exists
-					const metadata = config.loadMetadata() || {
-						version: "1.0.0",
-						lastSync: new Date().toISOString(),
-						rules: [],
-					};
+						// Check if rule already exists
+						const metadata = config.loadMetadata() || {
+							version: "1.0.0",
+							lastSync: new Date().toISOString(),
+							rules: [],
+						};
 
-					// フルパス形式で比較
-					const fullName = `@${owner}/${ruleName}`;
-					const existingRule = metadata.rules.find((r) => r.name === fullName);
+						// フルパス形式で比較
+						const fullName = `@${owner}/${ruleName}`;
+						const existingRule = metadata.rules.find((r) => r.name === fullName);
 
-					if (existingRule && !options?.force) {
-						spinner.fail(
-							chalk.yellow(
-								`Rule already exists (version ${existingRule.version}). Use --force to overwrite.`,
-							),
+						if (existingRule && !options?.force) {
+							spinner.fail(
+								chalk.yellow(
+									`Rule already exists (version ${existingRule.version}). Use --force to overwrite.`,
+								),
+							);
+							return;
+						}
+
+						// Get rule content with specific version if requested
+						const targetVersion = requestedVersion || rule.version;
+						spinner.text(`Downloading rule content (version ${targetVersion})...`);
+						const { content, version } = await api.getRuleContent(rule.id, requestedVersion);
+
+						// Update rule object with the actual version from content response
+						if (requestedVersion) {
+							rule.version = version;
+						}
+
+						// Save rule
+						spinner.text("Saving rule...");
+						const pulledRule = fileManager.saveRule(rule, content);
+
+						// Update metadata
+						if (existingRule) {
+							const index = metadata.rules.findIndex((r) => r.name === fullName);
+							metadata.rules[index] = pulledRule;
+							if (existingRule.version !== pulledRule.version) {
+								console.log(
+									chalk.blue(
+										`Updated from version ${existingRule.version} to ${pulledRule.version}`,
+									),
+								);
+							}
+						} else {
+							metadata.rules.push(pulledRule);
+						}
+
+						metadata.lastSync = new Date().toISOString();
+						config.saveMetadata(metadata);
+
+						spinner.succeed(
+							chalk.green(`Successfully installed ${packageName} (version ${pulledRule.version})`),
 						);
+						console.log(chalk.gray(`Rule saved to: ${config.getSymlinkDir()}/${packageName}.md`));
+
+						// メモリファイルに記録
+						spinner.stop();
+						const recordingSpinner = ora("Recording to memory file...").start();
+
+						try {
+							let targetFile: string;
+
+							if (options?.file) {
+								// ファイルが指定された場合
+								targetFile = memoryManager.resolveFilePath(options.file);
+
+								// プロジェクト外への保存の場合は警告
+								if (!targetFile.startsWith(process.cwd()) && !options?.noWarn) {
+									recordingSpinner.stop();
+									console.log(
+										chalk.yellow(
+											"⚠️  警告: プロジェクト外のファイルに記録しようとしています\n" +
+												"    推奨: プロジェクト内のCLAUDE.mdやCOPILOT.md等を使用\n" +
+												"    続行しますか？（自己責任）",
+										),
+									);
+
+									const { inquirer } = await import("../utils/prompt");
+									const { confirm } = await inquirer.prompt([
+										{
+											type: "confirm",
+											name: "confirm",
+											message: "続行",
+											default: false,
+										},
+									]);
+
+									if (!confirm) {
+										console.log(chalk.yellow("インストールはキャンセルされました"));
+										return;
+									}
+									recordingSpinner.start();
+								}
+							} else {
+								// 対話式で選択
+								recordingSpinner.stop();
+								targetFile = await promptMemoryFile(packageName);
+								recordingSpinner.start();
+							}
+
+							await memoryManager.addRule(targetFile, pulledRule);
+
+							// 表示用パスを取得
+							const displayPath = memoryManager.getDisplayPath(targetFile);
+							recordingSpinner.succeed(chalk.green(`✓ ${displayPath} に記録しました`));
+						} catch (error) {
+							recordingSpinner.fail(chalk.red("Failed to record to memory file"));
+							if (error instanceof Error) {
+								console.error(chalk.red(error.message));
+							}
+						}
+					} catch (error) {
+						spinner.fail(chalk.red("Failed to install rule"));
+						if (axios.isAxiosError(error)) {
+							if (error.response?.status === 404) {
+								const errorMessage = error.response?.data?.message || "Rule not found";
+								if (
+									errorMessage.includes("バージョンが見つかりません") ||
+									errorMessage.includes("version")
+								) {
+									console.error(
+										chalk.red(`Rule exists but no version information found for ${path}`),
+									);
+									console.error(
+										chalk.yellow("This may be a legacy rule without proper versioning."),
+									);
+								} else {
+									console.error(chalk.red(`Rule not found: ${path}`));
+								}
+							} else if (error.response?.status === 401) {
+								console.error(chalk.red("Authentication required. Please login first."));
+							} else {
+								console.error(chalk.red(error.response?.data?.message || error.message));
+							}
+						} else if (error instanceof Error) {
+							console.error(chalk.red(error.message));
+						} else {
+							console.error(chalk.red("An unexpected error occurred"));
+						}
+						process.exit(1);
+					}
+				} else {
+					// Install all rules from metadata
+					const spinner = ora("Installing rules...").start();
+					const metadata = config.loadMetadata();
+					if (!metadata || metadata.rules.length === 0) {
+						spinner.succeed(chalk.gray("No rules to install"));
 						return;
 					}
 
-					// Get rule content with specific version if requested
-					const targetVersion = requestedVersion || rule.version;
-					spinner.text(`Downloading rule content (version ${targetVersion})...`);
-					const { content, version } = await api.getRuleContent(rule.id, requestedVersion);
-
-					// Update rule object with the actual version from content response
-					if (requestedVersion) {
-						rule.version = version;
-					}
-
-					// Save rule
-					spinner.text("Saving rule...");
-					const pulledRule = fileManager.saveRule(rule, content);
-
-					// Update metadata
-					if (existingRule) {
-						const index = metadata.rules.findIndex((r) => r.name === fullName);
-						metadata.rules[index] = pulledRule;
-						if (existingRule.version !== pulledRule.version) {
-							console.log(
-								chalk.blue(`Updated from version ${existingRule.version} to ${pulledRule.version}`),
-							);
-						}
-					} else {
-						metadata.rules.push(pulledRule);
-					}
-
-					metadata.lastSync = new Date().toISOString();
-					config.saveMetadata(metadata);
-
-					spinner.succeed(
-						chalk.green(`Successfully installed ${packageName} (version ${pulledRule.version})`),
+					spinner.text(
+						`Installing ${metadata.rules.length} rule${metadata.rules.length > 1 ? "s" : ""}...`,
 					);
-					console.log(chalk.gray(`Rule saved to: ${config.getSymlinkDir()}/${packageName}.md`));
-				} catch (error) {
-					spinner.fail(chalk.red("Failed to install rule"));
-					if (axios.isAxiosError(error)) {
-						if (error.response?.status === 404) {
-							const errorMessage = error.response?.data?.message || "Rule not found";
-							if (
-								errorMessage.includes("バージョンが見つかりません") ||
-								errorMessage.includes("version")
-							) {
-								console.error(
-									chalk.red(`Rule exists but no version information found for ${path}`),
-								);
-								console.error(chalk.yellow("This may be a legacy rule without proper versioning."));
-							} else {
-								console.error(chalk.red(`Rule not found: ${path}`));
+
+					let installedCount = 0;
+					let errorCount = 0;
+
+					for (const rule of metadata.rules) {
+						try {
+							// Check if already exists
+							if (fileManager.ruleExists(rule)) {
+								fileManager.createSymlink(rule);
+								installedCount++;
+								continue;
 							}
-						} else if (error.response?.status === 401) {
-							console.error(chalk.red("Authentication required. Please login first."));
-						} else {
-							console.error(chalk.red(error.response?.data?.message || error.message));
-						}
-					} else if (error instanceof Error) {
-						console.error(chalk.red(error.message));
-					} else {
-						console.error(chalk.red("An unexpected error occurred"));
-					}
-					process.exit(1);
-				}
-			} else {
-				// Install all rules from metadata
-				const spinner = ora("Installing rules...").start();
-				const metadata = config.loadMetadata();
-				if (!metadata || metadata.rules.length === 0) {
-					spinner.succeed(chalk.gray("No rules to install"));
-					return;
-				}
 
-				spinner.text(
-					`Installing ${metadata.rules.length} rule${metadata.rules.length > 1 ? "s" : ""}...`,
-				);
+							// rule.name にはすでにフルパス形式が入っている
+							const path = rule.name;
+							spinner.text(`Installing ${path}...`);
 
-				let installedCount = 0;
-				let errorCount = 0;
+							// Get rule from server
+							const serverRule = await api.getRule(path);
+							const { content } = await api.getRuleContent(serverRule.id);
 
-				for (const rule of metadata.rules) {
-					try {
-						// Check if already exists
-						if (fileManager.ruleExists(rule)) {
-							fileManager.createSymlink(rule);
+							// Save rule
+							fileManager.saveRule(serverRule, content);
+
+							// Update version if not frozen
+							if (!options?.frozenLockfile) {
+								rule.version = serverRule.version;
+								rule.pulledAt = new Date().toISOString();
+							}
+
 							installedCount++;
-							continue;
-						}
+						} catch (error) {
+							errorCount++;
+							// rule.name にはすでにフルパス形式が入っている
+							const path = rule.name;
 
-						// rule.name にはすでにフルパス形式が入っている
-						const path = rule.name;
-						spinner.text(`Installing ${path}...`);
-
-						// Get rule from server
-						const serverRule = await api.getRule(path);
-						const { content } = await api.getRuleContent(serverRule.id);
-
-						// Save rule
-						fileManager.saveRule(serverRule, content);
-
-						// Update version if not frozen
-						if (!options?.frozenLockfile) {
-							rule.version = serverRule.version;
-							rule.pulledAt = new Date().toISOString();
-						}
-
-						installedCount++;
-					} catch (error) {
-						errorCount++;
-						// rule.name にはすでにフルパス形式が入っている
-						const path = rule.name;
-
-						if (axios.isAxiosError(error) && error.response?.status === 404) {
-							console.error(chalk.red(`\n✗ Rule not found: ${path}`));
-						} else {
-							console.error(chalk.red(`\n✗ Failed to install ${path}`));
+							if (axios.isAxiosError(error) && error.response?.status === 404) {
+								console.error(chalk.red(`\n✗ Rule not found: ${path}`));
+							} else {
+								console.error(chalk.red(`\n✗ Failed to install ${path}`));
+							}
 						}
 					}
-				}
 
-				// Save updated metadata if not frozen
-				if (!options?.frozenLockfile && installedCount > 0) {
-					metadata.lastSync = new Date().toISOString();
-					config.saveMetadata(metadata);
-				}
+					// Save updated metadata if not frozen
+					if (!options?.frozenLockfile && installedCount > 0) {
+						metadata.lastSync = new Date().toISOString();
+						config.saveMetadata(metadata);
+					}
 
-				spinner.stop();
+					spinner.stop();
 
-				if (installedCount > 0) {
-					console.log(
-						chalk.green(`\n✓ Installed ${installedCount} rule${installedCount > 1 ? "s" : ""}`),
-					);
-				}
+					if (installedCount > 0) {
+						console.log(
+							chalk.green(`\n✓ Installed ${installedCount} rule${installedCount > 1 ? "s" : ""}`),
+						);
+					}
 
-				if (errorCount > 0) {
-					console.log(
-						chalk.red(`\n✗ Failed to install ${errorCount} rule${errorCount > 1 ? "s" : ""}`),
-					);
-					process.exit(1);
+					if (errorCount > 0) {
+						console.log(
+							chalk.red(`\n✗ Failed to install ${errorCount} rule${errorCount > 1 ? "s" : ""}`),
+						);
+						process.exit(1);
+					}
 				}
-			}
-		});
+			},
+		);
 }

--- a/cli/src/utils/api.ts
+++ b/cli/src/utils/api.ts
@@ -47,7 +47,7 @@ export class ApiClient {
 	}
 
 	async login(username: string, password: string): Promise<{ token: string }> {
-		const response = await this.client.post("/api/auth/login", {
+		const response = await this.client.post("/auth/login", {
 			username,
 			password,
 		});
@@ -55,7 +55,7 @@ export class ApiClient {
 	}
 
 	async register(username: string, email: string, password: string): Promise<void> {
-		await this.client.post("/api/auth/register", {
+		await this.client.post("/auth/register", {
 			username,
 			email,
 			password,
@@ -63,7 +63,7 @@ export class ApiClient {
 	}
 
 	async getRule(path: string): Promise<Rule> {
-		const response = await this.client.post("/api/rules/getByPath", {
+		const response = await this.client.post("/rules/getByPath", {
 			path,
 		});
 		return response.data;
@@ -73,7 +73,7 @@ export class ApiClient {
 		ruleId: string,
 		version?: string,
 	): Promise<{ content: string; version: string }> {
-		const response = await this.client.post("/api/rules/getContent", {
+		const response = await this.client.post("/rules/getContent", {
 			id: ruleId,
 			...(version && { version }),
 		});
@@ -86,7 +86,7 @@ export class ApiClient {
 		visibility: "public" | "private";
 		tags: string[];
 	}): Promise<Rule> {
-		const response = await this.client.post("/api/rules/create", rule);
+		const response = await this.client.post("/rules/create", rule);
 		return response.data;
 	}
 
@@ -100,7 +100,7 @@ export class ApiClient {
 			changelog?: string;
 		},
 	): Promise<Rule> {
-		const response = await this.client.post("/api/rules/update", {
+		const response = await this.client.post("/rules/update", {
 			ruleId,
 			...updates,
 		});
@@ -115,7 +115,7 @@ export class ApiClient {
 		limit?: number;
 		offset?: number;
 	}): Promise<Rule[]> {
-		const response = await this.client.post("/api/rules/search", query);
+		const response = await this.client.post("/rules/search", query);
 		return response.data.rules;
 	}
 
@@ -126,7 +126,7 @@ export class ApiClient {
 			createdAt: string;
 		}>
 	> {
-		const response = await this.client.post("/api/rules/versions", {
+		const response = await this.client.post("/rules/versions", {
 			ruleId,
 		});
 		return response.data.versions;
@@ -134,7 +134,7 @@ export class ApiClient {
 
 	// Device Authorization Grant methods
 	async initializeDeviceAuth(): Promise<DeviceAuthData> {
-		const response = await this.client.post("/api/auth/device/authorize", {
+		const response = await this.client.post("/auth/device/authorize", {
 			clientId: "cli",
 			scope: "read write",
 		});
@@ -153,7 +153,7 @@ export class ApiClient {
 			await new Promise((resolve) => setTimeout(resolve, currentInterval * 1000));
 
 			try {
-				const response = await this.client.post("/api/auth/device/token", {
+				const response = await this.client.post("/auth/device/token", {
 					deviceCode,
 					clientId: "cli",
 				});

--- a/cli/src/utils/memory-file.ts
+++ b/cli/src/utils/memory-file.ts
@@ -1,0 +1,203 @@
+import { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { basename, dirname, isAbsolute, join, relative } from "node:path";
+import type { ConfigManager } from "../config";
+import type { PulledRule } from "../types";
+
+export class MemoryFileManager {
+	private readonly KNOWN_FILES = [
+		"CLAUDE.md",
+		"CLAUDE.local.md",
+		"COPILOT.md",
+		".github/copilot-instructions.md",
+		"CURSOR.md",
+		".cursorrules",
+		"CODEIUM.md",
+		"AI.md",
+	];
+
+	private config: ConfigManager;
+
+	constructor(config: ConfigManager) {
+		this.config = config;
+	}
+
+	// ファイルパスを解決（~展開など）
+	public resolveFilePath(path: string): string {
+		if (path.startsWith("~")) {
+			return path.replace("~", homedir());
+		}
+		if (isAbsolute(path)) {
+			return path;
+		}
+		return join(process.cwd(), path);
+	}
+
+	// 表示用パスを取得
+	public getDisplayPath(filePath: string): string {
+		const cwd = process.cwd();
+		const home = homedir();
+
+		if (filePath.startsWith(cwd)) {
+			return relative(cwd, filePath) || ".";
+		}
+		if (filePath.startsWith(home)) {
+			return `~${filePath.slice(home.length)}`;
+		}
+		return filePath;
+	}
+
+	// メモリファイルを検索
+	public findMemoryFiles(scope: "project" | "user" | "all"): string[] {
+		const files: string[] = [];
+
+		if (scope === "project" || scope === "all") {
+			const projectDir = process.cwd();
+			for (const fileName of this.KNOWN_FILES) {
+				const filePath = join(projectDir, fileName);
+				if (existsSync(filePath)) {
+					files.push(filePath);
+				}
+			}
+		}
+
+		if (scope === "user" || scope === "all") {
+			const userDir = homedir();
+			for (const fileName of this.KNOWN_FILES) {
+				const filePath = join(userDir, fileName);
+				if (existsSync(filePath)) {
+					files.push(filePath);
+				}
+			}
+		}
+
+		return files;
+	}
+
+	// ルールをメモリファイルに追加
+	public async addRule(filePath: string, rule: PulledRule): Promise<void> {
+		const rulePath = this.getRulePath(rule);
+		const homeDir = homedir();
+		const displayPath = rulePath.replace(homeDir, "~");
+
+		const entry = `\n## ${rule.name}\n@${displayPath}\n`;
+
+		if (!existsSync(filePath)) {
+			// ファイルを新規作成
+			const header = this.getFileHeader(basename(filePath));
+			mkdirSync(dirname(filePath), { recursive: true });
+			writeFileSync(filePath, header + entry);
+		} else {
+			// 既存ファイルに追記
+			const content = readFileSync(filePath, "utf-8");
+			if (!content.includes(`## ${rule.name}`)) {
+				appendFileSync(filePath, entry);
+			}
+		}
+	}
+
+	// ルールをメモリファイルから削除
+	public async removeRule(filePath: string, ruleName: string): Promise<void> {
+		if (!existsSync(filePath)) return;
+
+		const content = readFileSync(filePath, "utf-8");
+
+		// セクション全体を削除（## rulename から次の ## まで、または文末まで）
+		const lines = content.split("\n");
+		const updatedLines: string[] = [];
+		let skipMode = false;
+		let ruleFound = false;
+
+		for (let i = 0; i < lines.length; i++) {
+			const line = lines[i];
+
+			// ルールのセクション開始を検出
+			if (line === `## ${ruleName}`) {
+				skipMode = true;
+				ruleFound = true;
+				continue;
+			}
+
+			// 次のセクション開始を検出（スキップモード終了）
+			if (skipMode && line.startsWith("## ") && line !== `## ${ruleName}`) {
+				skipMode = false;
+			}
+
+			// スキップモードでない場合のみ行を保持
+			if (!skipMode) {
+				updatedLines.push(line);
+			}
+		}
+
+		if (ruleFound) {
+			// 末尾の空行を整理
+			while (updatedLines.length > 0 && updatedLines[updatedLines.length - 1] === "") {
+				updatedLines.pop();
+			}
+
+			const updatedContent = updatedLines.join("\n") + (updatedLines.length > 0 ? "\n" : "");
+			writeFileSync(filePath, updatedContent);
+		}
+	}
+
+	// プロジェクト内のメモリファイルからルールを削除
+	public async removeRuleFromProject(ruleName: string): Promise<string[]> {
+		const projectFiles = this.findMemoryFiles("project");
+		const updatedFiles: string[] = [];
+
+		for (const file of projectFiles) {
+			const content = readFileSync(file, "utf-8");
+			if (content.includes(`## ${ruleName}`)) {
+				await this.removeRule(file, ruleName);
+				updatedFiles.push(basename(file));
+			}
+		}
+
+		return updatedFiles;
+	}
+
+	// ファイルヘッダーを取得
+	private getFileHeader(fileName: string): string {
+		const headers: { [key: string]: string } = {
+			"CLAUDE.md": "# Claude Code Instructions\n\nAI coding rules for Claude Code\n",
+			"CLAUDE.local.md":
+				"# Claude Code Instructions (Local)\n\nProject-specific AI coding rules for Claude Code\n",
+			"COPILOT.md": "# GitHub Copilot Instructions\n\nAI coding rules for GitHub Copilot\n",
+			"CURSOR.md": "# Cursor Instructions\n\nAI coding rules for Cursor\n",
+			".cursorrules": "# Cursor Rules\n\n",
+			"CODEIUM.md": "# Codeium Instructions\n\nAI coding rules for Codeium\n",
+		};
+
+		return headers[fileName] || `# ${fileName}\n\nAI coding rules managed by zxcv\n`;
+	}
+
+	// ルールファイルのパスを取得
+	private getRulePath(rule: PulledRule): string {
+		const parsed = this.parseRuleName(rule.name);
+		const parts = [this.config.getRulesDir()];
+
+		if (parsed.owner) {
+			parts.push(`@${parsed.owner}`);
+		}
+		parts.push(`${parsed.name}.md`);
+
+		return join(...parts);
+	}
+
+	// ルール名をパース
+	private parseRuleName(fullName: string): { name: string; owner?: string } {
+		const parts = fullName.split("/");
+		if (parts.length === 2 && parts[0].startsWith("@")) {
+			// @username/rulename or @org/rulename
+			const owner = parts[0].substring(1);
+			return {
+				owner,
+				name: parts[1],
+			};
+		}
+		// rulename only (legacy)
+		return {
+			name: fullName,
+		};
+	}
+}


### PR DESCRIPTION
## Summary
- Implements GitHub issue #28: "ルールのインストールを行えるようにする" (Enable Rule Installation)
- Adds comprehensive rule installation functionality with automatic memory file recording
- Implements npm-like behavior for rule management

## Key Features
- **Memory File Management**: New `MemoryFileManager` class handles AI tool configuration files (CLAUDE.md, COPILOT.md, .cursorrules, etc.)
- **Interactive Prompts**: User-friendly selection interface for choosing where to record installed rules
- **Project-Level Priority**: Defaults to project-level files with warnings for user-level files
- **npm-like Removal**: Keeps global rule files while only removing project metadata
- **API Fixes**: Corrected endpoint path duplication issues

## Test Results
✅ Successfully tested with real API (`@345e6t7yu/test` rule)  
✅ Installation with interactive memory file selection works  
✅ Removal preserves global files while cleaning project metadata  
✅ API connectivity and rule download confirmed  

## Technical Details
- **New Files**: 
  - `src/utils/memory-file.ts` - Core memory file management
  - Enhanced `src/utils/prompt.ts` - Interactive prompts
- **Enhanced Commands**:
  - `install` command: Added `--file` and `--no-warn` options
  - `remove` command: Automatic memory file cleanup
- **Dependencies**: Added inquirer for better CLI interactions
- **API Fixes**: Corrected all endpoint paths to prevent `/api/api` duplication

## Usage
```bash
# Install rule with interactive prompt
zxcv install @owner/rulename

# Install to specific file
zxcv install @owner/rulename --file CLAUDE.md

# Remove rule (npm-like behavior)
zxcv remove @owner/rulename
```

Closes #28

🤖 Generated with [Claude Code](https://claude.ai/code)